### PR TITLE
Refactor compute wss

### DIFF
--- a/postprocessing/compute_wss.py
+++ b/postprocessing/compute_wss.py
@@ -159,7 +159,7 @@ def compute_wss(case_path, nu, dt, velocity_degree):
         save = False
 
     if save:
-        # Save WSS_abs and RRT
+        # Save OSI and RRT
         rrt_path = (case_path / "RRT.xdmf").__str__()
         osi_path = (case_path / "OSI.xdmf").__str__()
 


### PR DESCRIPTION
Refactor and recomputation of hemodynamic indices, according to the attached image. Current implementation and naming conventions can easily be misunderstood. 
In the suggested implementation: 
- WSS_abs = AWSS
- WSS_mean = AWSSV
- OSI implemented as is
- RRT is equivalent to 1 / WSS_mean

<img width="583" alt="Screenshot 2021-06-01 at 09 52 15" src="https://user-images.githubusercontent.com/9609456/120481249-36717e00-c3b0-11eb-89e2-03ddddd80aba.png">
