### PR TITLE
Add mutually exclusive groups and more verbose formatter class

### DIFF
--- a/automatedPreProcessing/automatedPreProcessing.py
+++ b/automatedPreProcessing/automatedPreProcessing.py
@@ -346,14 +346,15 @@ def read_command_line():
     """
     Read arguments from commandline and return all values in a dictionary.
     """
-    parser = argparse.ArgumentParser(
-        description="Automated pre-processing for vascular modeling.")
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+                                     description="Automated pre-processing for vascular modeling.")
 
-    parser.add_argument('-v', '--verbosity',
-                        dest='verbosity',
-                        type=str2bool,
-                        default=False,
-                        help="Activates the verbose mode.")
+    v = parser.add_mutually_exclusive_group(required=False)
+    v.add_argument('-v', '--verbosity',
+                   dest='verbosity',
+                   action='store_true',
+                   default=False,
+                   help="Activates the verbose mode.")
 
     parser.add_argument('-i', '--inputModel',
                         type=str,
@@ -361,13 +362,12 @@ def read_command_line():
                         dest='fileNameModel',
                         default='example/surface.vtp',
                         help="Input file containing the 3D model.")
-
-    parser.add_argument('-cM', '--compress-mesh',
-                        type=str2bool,
-                        required=False,
-                        dest='compressMesh',
-                        default=True,
-                        help="Compress output mesh after generation.")
+    cm = parser.add_mutually_exclusive_group(required=False)
+    cm.add_argument('-ncM', '--no-compress-mesh',
+                    default=True,
+                    dest='compressMesh',
+                    action='store_false',
+                    help="Do not compress output mesh after generation.")
 
     parser.add_argument('-sM', '--smoothingMethod',
                         type=str,
@@ -406,12 +406,13 @@ def read_command_line():
                         type=float,
                         help="Characteristic edge length used for meshing.")
 
-    parser.add_argument('-r', '--refine-region',
-                        dest="refineRegion",
-                        type=str2bool,
-                        default=False,
-                        help="Determine weather or not to refine a specific region of " +
-                             "the input model. Default is False.")
+    refine_region = parser.add_mutually_exclusive_group(required=False)
+    refine_region.add_argument('-r', '--refine-region',
+                               action='store_true',
+                               dest="refineRegion",
+                               default=False,
+                               help="Determine whether or not to refine a specific region of " +
+                                    "the input model")
 
     parser.add_argument('-rp', '--region-points',
                         dest="regionPoints",
@@ -423,17 +424,19 @@ def read_command_line():
                              "Example providing the points (0.1, 5.0, -1) and (1, -5.2, 3.21):" +
                              " --region-points 0.1 5 -1 1 5.24 3.21")
 
-    parser.add_argument('-at', '--atrium',
+    atrium = parser.add_mutually_exclusive_group(required=False)
+    atrium.add_argument('-at', '--atrium',
                         dest="isAtrium",
-                        type=str2bool,
+                        action="store_true",
                         default=False,
-                        help="Determine weather or not the model is an Atrium model. Default is False.")
+                        help="Determine whether or not the model is an Atrium model.")
 
-    parser.add_argument('-f', '--flowext',
-                        dest="flowExtension",
-                        default=True,
-                        type=str2bool,
-                        help="Add flow extensions to to the model.")
+    flowext = parser.add_mutually_exclusive_group(required=False)
+    flowext.add_argument('-nf', '--no-flowext',
+                         dest="flowExtension",
+                         default=True,
+                         action="store_false",
+                         help="Remove flow extensions from the model.")
 
     parser.add_argument('-fli', '--inletFlowext',
                         dest="inletFlowExtLen",
@@ -447,11 +450,12 @@ def read_command_line():
                         type=float,
                         help="Length of flow extensions at outlet(s).")
 
-    parser.add_argument('-vz', '--visualize',
+    visualize = parser.add_mutually_exclusive_group(required=False)
+    visualize.add_argument('-nvz', '--no-visualize',
                         dest="viz",
                         default=True,
-                        type=str2bool,
-                        help="Visualize surface, inlet, outlet and probes after meshing.")
+                        action="store_false",
+                        help="Skip visualizing surface, inlet, outlet and probes after meshing.")
 
     parser.add_argument('-sc', '--simulation-config',
                         type=str,

--- a/automatedPreProcessing/automatedPreProcessing.py
+++ b/automatedPreProcessing/automatedPreProcessing.py
@@ -362,12 +362,12 @@ def read_command_line():
                         dest='fileNameModel',
                         default='example/surface.vtp',
                         help="Input file containing the 3D model.")
-    cm = parser.add_mutually_exclusive_group(required=False)
-    cm.add_argument('-ncM', '--no-compress-mesh',
-                    default=True,
-                    dest='compressMesh',
-                    action='store_false',
-                    help="Do not compress output mesh after generation.")
+    parser.add_argument('-cM', '--compress-mesh',
+                        type=str2bool,
+                        required=False,
+                        dest='compressMesh',
+                        default=True,
+                        help="Compress output mesh after generation.")
 
     parser.add_argument('-sM', '--smoothingMethod',
                         type=str,
@@ -431,12 +431,11 @@ def read_command_line():
                         default=False,
                         help="Determine whether or not the model is an Atrium model.")
 
-    flowext = parser.add_mutually_exclusive_group(required=False)
-    flowext.add_argument('-nf', '--no-flowext',
-                         dest="flowExtension",
-                         default=True,
-                         action="store_false",
-                         help="Remove flow extensions from the model.")
+    parser.add_argument('-f', '--flowext',
+                        dest="flowExtension",
+                        default=True,
+                        type=str2bool,
+                        help="Add flow extensions to to the model.")
 
     parser.add_argument('-fli', '--inletFlowext',
                         dest="inletFlowExtLen",
@@ -450,12 +449,11 @@ def read_command_line():
                         type=float,
                         help="Length of flow extensions at outlet(s).")
 
-    visualize = parser.add_mutually_exclusive_group(required=False)
-    visualize.add_argument('-nvz', '--no-visualize',
+    parser.add_argument('-vz', '--visualize',
                         dest="viz",
                         default=True,
-                        action="store_false",
-                        help="Skip visualizing surface, inlet, outlet and probes after meshing.")
+                        type=str2bool,
+                        help="Visualize surface, inlet, outlet and probes after meshing.")
 
     parser.add_argument('-sc', '--simulation-config',
                         type=str,


### PR DESCRIPTION
Current argparse gives the following:
```bash
python3 automatedPreProcessing/automatedPreProcessing.py -h
usage: automatedPreProcessing.py [-h] [-v VERBOSITY] [-i FILENAMEMODEL] [-cM COMPRESSMESH]
                                 [-sM {voronoi,no_smooth,laplace,taubin}] [-c COARSENINGFACTOR] [-sF SMOOTHINGFACTOR]
                                 [-m {diameter,curvature,constant}] [-el EDGELENGTH] [-r REFINEREGION]
                                 [-rp REGIONPOINTS [REGIONPOINTS ...]] [-at ISATRIUM] [-f FLOWEXTENSION]
                                 [-fli INLETFLOWEXTLEN] [-flo OUTLETFLOWEXTLEN] [-vz VIZ] [-sc CONFIG]

Automated pre-processing for vascular modeling.

options:
  -h, --help            show this help message and exit
  -v VERBOSITY, --verbosity VERBOSITY
                        Activates the verbose mode.
  -i FILENAMEMODEL, --inputModel FILENAMEMODEL
                        Input file containing the 3D model.
  -cM COMPRESSMESH, --compress-mesh COMPRESSMESH
                        Compress output mesh after generation.
  -sM {voronoi,no_smooth,laplace,taubin}, --smoothingMethod {voronoi,no_smooth,laplace,taubin}
                        Smoothing method, for now only Voronoi smoothing is available. For Voronoi smoothing you can
                        also control smoothingFactor (default = 0.25).
  -c COARSENINGFACTOR, --coarseningFactor COARSENINGFACTOR
                        Refine or coarsen the standard mesh size. The higher the value the coarser the mesh.
  -sF SMOOTHINGFACTOR, --smoothingFactor SMOOTHINGFACTOR
                        smoothingFactor for VoronoiSmoothing, removes all spheres which has a radius < MISR*(1-0.25),
                        where MISR varying along the centerline.
  -m {diameter,curvature,constant}, --meshingMethod {diameter,curvature,constant}
  -el EDGELENGTH, --edge-length EDGELENGTH
                        Characteristic edge length used for meshing.
  -r REFINEREGION, --refine-region REFINEREGION
                        Determine weather or not to refine a specific region of the input model. Default is False.
  -rp REGIONPOINTS [REGIONPOINTS ...], --region-points REGIONPOINTS [REGIONPOINTS ...]
                        If -r or --refine-region is True, the user can provide the point(s) which defines the regions
                        to refine. Example providing the points (0.1, 5.0, -1) and (1, -5.2, 3.21): --region-points 0.1
                        5 -1 1 5.24 3.21
  -at ISATRIUM, --atrium ISATRIUM
                        Determine weather or not the model is an Atrium model. Default is False.
  -f FLOWEXTENSION, --flowext FLOWEXTENSION
                        Add flow extensions to to the model.
  -fli INLETFLOWEXTLEN, --inletFlowext INLETFLOWEXTLEN
                        Length of flow extensions at inlet(s).
  -flo OUTLETFLOWEXTLEN, --outletFlowext OUTLETFLOWEXTLEN
                        Length of flow extensions at outlet(s).
  -vz VIZ, --visualize VIZ
                        Visualize surface, inlet, outlet and probes after meshing.
  -sc CONFIG, --simulation-config CONFIG
                        Path to configuration file for remote simulation. See example/ssh_config.json for details
```

New argparser shows:
```bash
python3 automatedPreProcessing/automatedPreProcessing.py -h
usage: automatedPreProcessing.py [-h] [-v] [-i FILENAMEMODEL] [-cM COMPRESSMESH]
                                 [-sM {voronoi,no_smooth,laplace,taubin}] [-c COARSENINGFACTOR] [-sF SMOOTHINGFACTOR]
                                 [-m {diameter,curvature,constant}] [-el EDGELENGTH] [-r]
                                 [-rp REGIONPOINTS [REGIONPOINTS ...]] [-at] [-f FLOWEXTENSION] [-fli INLETFLOWEXTLEN]
                                 [-flo OUTLETFLOWEXTLEN] [-vz VIZ] [-sc CONFIG]

Automated pre-processing for vascular modeling.

options:
  -h, --help            show this help message and exit
  -v, --verbosity       Activates the verbose mode. (default: False)
  -i FILENAMEMODEL, --inputModel FILENAMEMODEL
                        Input file containing the 3D model. (default: example/surface.vtp)
  -cM COMPRESSMESH, --compress-mesh COMPRESSMESH
                        Compress output mesh after generation. (default: True)
  -sM {voronoi,no_smooth,laplace,taubin}, --smoothingMethod {voronoi,no_smooth,laplace,taubin}
                        Smoothing method, for now only Voronoi smoothing is available. For Voronoi smoothing you can
                        also control smoothingFactor (default = 0.25). (default: no_smooth)
  -c COARSENINGFACTOR, --coarseningFactor COARSENINGFACTOR
                        Refine or coarsen the standard mesh size. The higher the value the coarser the mesh. (default:
                        1.0)
  -sF SMOOTHINGFACTOR, --smoothingFactor SMOOTHINGFACTOR
                        smoothingFactor for VoronoiSmoothing, removes all spheres which has a radius < MISR*(1-0.25),
                        where MISR varying along the centerline. (default: 0.25)
  -m {diameter,curvature,constant}, --meshingMethod {diameter,curvature,constant}
  -el EDGELENGTH, --edge-length EDGELENGTH
                        Characteristic edge length used for meshing. (default: None)
  -r, --refine-region   Determine whether or not to refine a specific region of the input model (default: False)
  -rp REGIONPOINTS [REGIONPOINTS ...], --region-points REGIONPOINTS [REGIONPOINTS ...]
                        If -r or --refine-region is True, the user can provide the point(s) which defines the regions
                        to refine. Example providing the points (0.1, 5.0, -1) and (1, -5.2, 3.21): --region-points 0.1
                        5 -1 1 5.24 3.21 (default: None)
  -at, --atrium         Determine whether or not the model is an Atrium model. (default: False)
  -f FLOWEXTENSION, --flowext FLOWEXTENSION
                        Add flow extensions to to the model. (default: True)
  -fli INLETFLOWEXTLEN, --inletFlowext INLETFLOWEXTLEN
                        Length of flow extensions at inlet(s). (default: 5)
  -flo OUTLETFLOWEXTLEN, --outletFlowext OUTLETFLOWEXTLEN
                        Length of flow extensions at outlet(s). (default: 5)
  -vz VIZ, --visualize VIZ
                        Visualize surface, inlet, outlet and probes after meshing. (default: True)
  -sc CONFIG, --simulation-config CONFIG
                        Path to configuration file for remote simulation. See example/ssh_config.json for details
                        (default: None)
```