### PR TITLE
Update `Womersley.py`

### DIFF
--- a/src/vampy/simulation/Artery.py
+++ b/src/vampy/simulation/Artery.py
@@ -108,10 +108,10 @@ def create_bcs(t, NS_expressions, V, Q, area_ratio, area_inlet, mesh, mesh_path,
     t_values, Q_ = np.loadtxt(path.join(path.dirname(path.abspath(__file__)), "ICA_values")).T
     Q_values = Q_mean * Q_  # Specific flow rate = Normalized flow wave form * Prescribed flow rate
     t_values *= 1000  # Scale time in normalised flow wave form to [ms]
-    tmp_area, tmp_center, tmp_radius, tmp_normal = compute_boundary_geometry_acrn(mesh, id_in[0], boundary)
+    _, tmp_center, tmp_radius, tmp_normal = compute_boundary_geometry_acrn(mesh, id_in[0], boundary)
 
     # Create Womersley boundary condition at inlet
-    inlet = make_womersley_bcs(t_values, Q_values, mesh, nu, tmp_area, tmp_center, tmp_radius, tmp_normal,
+    inlet = make_womersley_bcs(t_values, Q_values, nu, tmp_center, tmp_radius, tmp_normal,
                                V.ufl_element())
     NS_expressions["inlet"] = inlet
 

--- a/src/vampy/simulation/Atrium.py
+++ b/src/vampy/simulation/Atrium.py
@@ -116,8 +116,8 @@ def create_bcs(NS_expressions, mesh, mesh_path, nu, t, V, Q, id_in, id_out, **NS
         Q_scaled = Q_values * tmp_area / area_total
 
         # Create Womersley boundary condition at inlet
-        inlet = make_womersley_bcs(t_values, Q_scaled, mesh, nu, tmp_area, tmp_center, tmp_radius, tmp_normal,
-                                   V.ufl_element())
+        inlet = make_womersley_bcs(t_values, Q_scaled, nu, tmp_center, tmp_radius, tmp_normal,
+                               V.ufl_element())
         NS_expressions["inlet_{}".format(ID)] = inlet
 
     # Initial condition

--- a/src/vampy/simulation/Atrium.py
+++ b/src/vampy/simulation/Atrium.py
@@ -117,7 +117,7 @@ def create_bcs(NS_expressions, mesh, mesh_path, nu, t, V, Q, id_in, id_out, **NS
 
         # Create Womersley boundary condition at inlet
         inlet = make_womersley_bcs(t_values, Q_scaled, nu, tmp_center, tmp_radius, tmp_normal,
-                               V.ufl_element())
+                                   V.ufl_element())
         NS_expressions["inlet_{}".format(ID)] = inlet
 
     # Initial condition

--- a/src/vampy/simulation/Womersley.py
+++ b/src/vampy/simulation/Womersley.py
@@ -231,23 +231,23 @@ class WomersleyComponent(UserExpression):
         value[0] = -self.normal_component * self.scale_value * wom
 
 
-def make_womersley_bcs(t, Q, nu, center, radius, normal, element, coeffstype="Q", 
+def make_womersley_bcs(t, Q, nu, center, radius, normal, element, coeffstype="Q",
                        N=1001, num_fourier_coefficients=20, Cn=None, **NS_namespace):
     """
     Generate a list of expressions for the components of a Womersley profile.
-    Users can specify either the flow rate or fourier coefficients of the flow rate 
+    Users can specify either the flow rate or fourier coefficients of the flow rate
     depending on if Cn is None or not.
     """
     # period is usually the lenght of a cardiac cycle (0.951 s)
     # If t is a list or numpy array, then period is the maximum value of t
     # If not, simply assign t as period
-    try :
+    try:
         period = max(t)
     except TypeError:
         period = t
 
     # Compute fourier coefficients of transient profile if Cn is None
-    if Cn is None:    
+    if Cn is None:
         # Compute transient profile as interpolation of given coefficients
         transient_profile = UnivariateSpline(t, Q, s=0, k=1)
 

--- a/src/vampy/simulation/Womersley.py
+++ b/src/vampy/simulation/Womersley.py
@@ -231,18 +231,30 @@ class WomersleyComponent(UserExpression):
         value[0] = -self.normal_component * self.scale_value * wom
 
 
-def make_womersley_bcs(t, Q, mesh, nu, area, center, radius, normal,
-                       element, scale_to=None, coeffstype="Q",
-                       N=1001, num_fourier_coefficients=20, **NS_namespace):
-    """Generate a list of expressions for the components of a Womersley profile."""
-    # Compute transient profile as interpolation of given coefficients
-    period = max(t)
-    transient_profile = UnivariateSpline(t, Q, s=0, k=1)
+def make_womersley_bcs(t, Q, nu, center, radius, normal, element, coeffstype="Q", 
+                       N=1001, num_fourier_coefficients=20, Cn=None, **NS_namespace):
+    """
+    Generate a list of expressions for the components of a Womersley profile.
+    Users can specify either the flow rate or fourier coefficients of the flow rate 
+    depending on if Cn is None or not.
+    """
+    # period is usually the lenght of a cardiac cycle (0.951 s)
+    # If t is a list or numpy array, then period is the maximum value of t
+    # If not, simply assign t as period
+    try :
+        period = max(t)
+    except TypeError:
+        period = t
 
-    # Compute fourier coefficients of transient profile
-    timedisc = np.linspace(0, period, N)
+    # Compute fourier coefficients of transient profile if Cn is None
+    if Cn is None:    
+        # Compute transient profile as interpolation of given coefficients
+        transient_profile = UnivariateSpline(t, Q, s=0, k=1)
 
-    Cn = fourier_coefficients(timedisc, transient_profile, period, num_fourier_coefficients)
+        # Compute fourier coefficients of transient profile
+        timedisc = np.linspace(0, period, N)
+
+        Cn = fourier_coefficients(timedisc, transient_profile, period, num_fourier_coefficients)
 
     # Create Expressions for each direction
     expressions = []


### PR DESCRIPTION
Hi @hkjeldsberg 

We had a new implementation of `make_womersley_bc` in `Womersley.py` (@dbruneau-mie’s contribution), where users can directly give Fourier coefficients of the flow rate instead of computing Fourier coefficients based on the specific flow rates. This PR adds such a functionality into `VaMPy` since we are aiming to use as much functionality as possible from `VaMPy`.
 
In addition, there were a few variables that were passed inside the function, but not used (`mesh`, `nu`, `tmp_area`), so I removed them. 

I tested the implementation with `Artery.py` with tiny artery for two cardiac cycles and compared hemodynamics. Since hemodynamics were identical, I assume this implementation should not affect any problem files in VaMPy but would be nice if you could also check. 

Please let me know if you have any questions!

Best,
Kei