### PR TITLE
modify dependency

### DIFF
--- a/src/vampy/__init__.py
+++ b/src/vampy/__init__.py
@@ -28,7 +28,7 @@ try:
     from .simulation import Womersley
     from .simulation import simulation_common
 except ModuleNotFoundError:
-    print("Oasis is not installed, running CFD is not available")
+    print("WARNING: Oasis is not installed, running CFD is not available")
 
 
 meta = metadata("vampy")

--- a/src/vampy/__init__.py
+++ b/src/vampy/__init__.py
@@ -8,21 +8,27 @@ from .automatedPostprocessing import compute_velocity_and_pressure
 from .automatedPostprocessing import postprocessing_common
 from .automatedPostprocessing import visualize_probes
 # Imports from pre-processing
-from .automatedPreprocessing import DisplayData
-from .automatedPreprocessing import ImportData
-from .automatedPreprocessing import NetworkBoundaryConditions
-from .automatedPreprocessing import ToolRepairSTL
-from .automatedPreprocessing import automated_preprocessing
-from .automatedPreprocessing import preprocessing_common
-from .automatedPreprocessing import simulate
-from .automatedPreprocessing import visualize
-from .automatedPreprocessing import vmtk_pointselector
+try :
+    from .automatedPreprocessing import DisplayData
+    from .automatedPreprocessing import ImportData
+    from .automatedPreprocessing import NetworkBoundaryConditions
+    from .automatedPreprocessing import ToolRepairSTL
+    from .automatedPreprocessing import automated_preprocessing
+    from .automatedPreprocessing import preprocessing_common
+    from .automatedPreprocessing import simulate
+    from .automatedPreprocessing import visualize
+    from .automatedPreprocessing import vmtk_pointselector
+except ModuleNotFoundError :
+    print("morphman is not installed, automated preprocessing is not available")
 # Imports from simulation scripts
-from .simulation import Artery
-from .simulation import Atrium
-from .simulation import Probe
-from .simulation import Womersley
-from .simulation import simulation_common
+try :
+    from .simulation import Artery
+    from .simulation import Atrium
+    from .simulation import Probe
+    from .simulation import Womersley
+    from .simulation import simulation_common
+except ModuleNotFoundError :
+    print("oasis is not installed, running CFD is not available")
 
 
 meta = metadata("vampy")

--- a/src/vampy/__init__.py
+++ b/src/vampy/__init__.py
@@ -8,7 +8,7 @@ from .automatedPostprocessing import compute_velocity_and_pressure
 from .automatedPostprocessing import postprocessing_common
 from .automatedPostprocessing import visualize_probes
 # Imports from pre-processing
-try :
+try:
     from .automatedPreprocessing import DisplayData
     from .automatedPreprocessing import ImportData
     from .automatedPreprocessing import NetworkBoundaryConditions
@@ -18,17 +18,17 @@ try :
     from .automatedPreprocessing import simulate
     from .automatedPreprocessing import visualize
     from .automatedPreprocessing import vmtk_pointselector
-except ModuleNotFoundError :
-    print("morphman is not installed, automated preprocessing is not available")
+except ModuleNotFoundError:
+    print("WARNING: morphMan is not installed, automated preprocessing is not available")
 # Imports from simulation scripts
-try :
+try:
     from .simulation import Artery
     from .simulation import Atrium
     from .simulation import Probe
     from .simulation import Womersley
     from .simulation import simulation_common
-except ModuleNotFoundError :
-    print("oasis is not installed, running CFD is not available")
+except ModuleNotFoundError:
+    print("Oasis is not installed, running CFD is not available")
 
 
 meta = metadata("vampy")

--- a/src/vampy/simulation/__init__.py
+++ b/src/vampy/simulation/__init__.py
@@ -1,5 +1,8 @@
-from . import Artery
-from . import Atrium
-from . import simulation_common
-from . import Womersley
-from . import Probe
+try :
+    from . import Artery
+    from . import Atrium
+    from . import simulation_common
+    from . import Womersley
+    from . import Probe
+except ModuleNotFoundError :
+    print("oasis is not installed, running CFD is not available")

--- a/src/vampy/simulation/__init__.py
+++ b/src/vampy/simulation/__init__.py
@@ -1,8 +1,8 @@
-try :
+try:
     from . import Artery
     from . import Atrium
     from . import simulation_common
     from . import Womersley
     from . import Probe
-except ModuleNotFoundError :
-    print("oasis is not installed, running CFD is not available")
+except ModuleNotFoundError:
+    print("WARNING: Oasis is not installed, running CFD is not available")


### PR DESCRIPTION
Hi, 

We would like to use vampy without installing oasis, morphman (vmtk) for our FSI framework, but currently it is not possible. 
Therefore, I modified some of the `__init__.py` files so that we can use vampy without these packages. 
There might be better way to do this, so please let me know if you have any suggestions!

Best,
Kei 