### PR TITLE
fix code coverage report

### DIFF
--- a/.github/workflows/check_and_test_package.yml
+++ b/.github/workflows/check_and_test_package.yml
@@ -93,7 +93,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Install VaMPy
-        run: python3 -m pip install .[test]
+        run: python3 -m pip install --editable .[test]
 
       - name: Run tests
         run: python3 -m pytest tests


### PR DESCRIPTION
I noticed that code coverage is not accurate with github actions. Right now, it shows the coverage of the test script itself and not the coverage of the scripts inside `src` folders. Adding `--editable` flag should fix the issue. 