### PR TITLE
import numpy in problem file

### DIFF
--- a/src/vampy/simulation/Artery.py
+++ b/src/vampy/simulation/Artery.py
@@ -2,6 +2,7 @@ import json
 import os
 import pickle
 from pprint import pprint
+import numpy as np
 from dolfin import set_log_level
 
 if os.environ.get('OASIS_MODE') == 'TESTING':


### PR DESCRIPTION
When trying to run `Artery.py` out of box. I got an import error. Adding `import numpy as np` fixes the issue.