### PR TITLE
Hotfix for expat dependency (VTK)

### DIFF
--- a/.github/workflows/check_and_test_package.yml
+++ b/.github/workflows/check_and_test_package.yml
@@ -15,7 +15,7 @@ on:
     - cron: "0 8 * * *"
 
 env:
-  CACHE_NUMBER: 10 # Increase to reset cache
+  CACHE_NUMBER: 11 # Increase to reset cache
 
 jobs:
   check-code:

--- a/environment-test.yml
+++ b/environment-test.yml
@@ -8,12 +8,11 @@ dependencies:
   - morphman
   - paramiko
   - pip
-  - python ==3.8.15
   - git
-  - vtk <= 9.1.0
-  - numpy <= 1.24.4
+  - python >=3.8
+  - expat==2.5 # Hotfix for https://gitlab.archlinux.org/archlinux/packaging/packages/paraview/-/issues/4
   - pip:
       - matplotlib
       - scipy
-      - cppimport==22.8.2
+      - cppimport
       - git+https://github.com/KVSlab/OasisMove

--- a/environment-test.yml
+++ b/environment-test.yml
@@ -8,7 +8,7 @@ dependencies:
   - morphman
   - paramiko
   - pip
-  - python >=3.8
+  - python <=3.10
   - git
   - pip:
       - scipy

--- a/environment-test.yml
+++ b/environment-test.yml
@@ -10,6 +10,8 @@ dependencies:
   - pip
   - python <=3.10
   - git
+  - vtk <= 9.1
+  - numpy <= 1.24.4
   - pip:
       - scipy
       - cppimport

--- a/environment-test.yml
+++ b/environment-test.yml
@@ -8,11 +8,12 @@ dependencies:
   - morphman
   - paramiko
   - pip
-  - python <=3.10
+  - python ==3.8.15
   - git
-  - vtk <= 9.1
+  - vtk <= 9.1.0
   - numpy <= 1.24.4
   - pip:
+      - matplotlib
       - scipy
-      - cppimport
+      - cppimport==22.8.2
       - git+https://github.com/KVSlab/OasisMove

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - morphman
   - paramiko
   - pip
-  - python >=3.8
+  - python <=3.10
   - git
   - pip:
       - scipy

--- a/environment.yml
+++ b/environment.yml
@@ -8,8 +8,9 @@ dependencies:
   - morphman
   - paramiko
   - pip
-  - python <=3.10
   - git
+  - python >=3.8
+  - expat==2.5 # Hotfix for https://gitlab.archlinux.org/archlinux/packaging/packages/paraview/-/issues/4
   - pip:
       - scipy
       - cppimport

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-jupyter-book
-matplotlib
-numpy
-ghp-import
-cppimport
-scipy

--- a/src/vampy/automatedPreprocessing/automated_preprocessing.py
+++ b/src/vampy/automatedPreprocessing/automated_preprocessing.py
@@ -1,15 +1,17 @@
 import argparse
-import numpy as np
 import sys
-from morphman import get_uncapped_surface, write_polydata, get_parameters, vtk_clean_polydata, \
+from os import remove, path
+
+import numpy as np
+from morphman import get_uncapped_surface, write_polydata, read_polydata, get_parameters, vtk_clean_polydata, \
     vtk_triangulate_surface, write_parameters, vmtk_cap_polydata, compute_centerlines, get_centerline_tolerance, \
     get_vtk_point_locator, extract_single_line, vtk_merge_polydata, get_point_data_array, smooth_voronoi_diagram, \
     create_new_surface, compute_centers, vmtk_smooth_surface, str2bool, vmtk_compute_voronoi_diagram, \
     prepare_output_surface, vmtk_compute_geometric_features
-from os import remove, path
+
 # Local imports
 from vampy.automatedPreprocessing.moving_common import get_point_map, project_displacement, save_displacement
-from vampy.automatedPreprocessing.preprocessing_common import read_polydata, get_centers_for_meshing, \
+from vampy.automatedPreprocessing.preprocessing_common import get_centers_for_meshing, \
     dist_sphere_diam, dist_sphere_curvature, dist_sphere_constant, get_regions_to_refine, add_flow_extension, \
     write_mesh, mesh_alternative, generate_mesh, find_boundaries, compute_flow_rate, setup_model_network, \
     radiusArrayName, scale_surface, get_furtest_surface_point, check_if_closed_surface, remesh_surface

--- a/src/vampy/simulation/Probe.py
+++ b/src/vampy/simulation/Probe.py
@@ -15,11 +15,12 @@ from numpy import zeros, squeeze, save
 ProbeObject = object
 
 try:
-    probe11 = cppimport.imp('vampy.simulation.probe.probe11')
+    probe11 = cppimport.imp('probe.probe11')
     ProbeObject = probe11.Probes
     print("Successfully imported probe.probe11")
-except ImportError:
+except ImportError as e:
     print("Failed to import probe.probe11")
+    print(f"Error message: {e}")
 
 
 # Give the compiled classes some additional pythonic functionality


### PR DESCRIPTION
- Hotfix for breaking `expat` vtk dependency
  - https://gitlab.archlinux.org/archlinux/packaging/packages/paraview/-/issues/4
- Adjust probe path in `Probe.py`