### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,14 @@ geometries.
 
 Installation
 ------------
-VaMPy is a Python package for Python >= 3.8, with main dependencies to [morphMan](https://github.com/KVSlab/morphMan)
-and [Oasis](https://github.com/mikaem/Oasis). VaMPy and its dependencies can be installed with `conda` on Linux and
-macOS as explained [here](https://kvslab.github.io/VaMPy/conda.html). The package can also be installed and run through
-its latest `Docker` image supported by Windows, Linux, and macOS, and
-explained [here](https://kvslab.github.io/VaMPy/docker.html).
+VaMPy is a Python package for Python >= 3.8, with main dependencies to [morphMan](https://github.com/KVSlab/morphMan) and [Oasis](https://github.com/mikaem/Oasis). VaMPy and its dependencies can be installed with `conda` on n Linux and  
+macOS using the following command:
+
+```
+conda create -n your_environment -c conda-forge vampy
+```
+
+More details on installation via `conda` can be found [here](https://kvslab.github.io/VaMPy/conda.html). The package can also be installed and run through its latest `Docker` image supported by Windows, Linux, and macOS, and explained [here](https://kvslab.github.io/VaMPy/docker.html).
 
 Documentation
 -------------

--- a/docs/conda.md
+++ b/docs/conda.md
@@ -15,6 +15,22 @@ installation of all the dependencies.
 
 ## Installation on Linux or macOS
 
+The easiest way to install `VaMPy` and its dependencies is via `conda-forge`. Run the following command in your terminal:
+
+```
+conda create -n your_environment -c conda-forge vampy
+```
+
+Once the installation is complete, activate the newly created environment:
+
+```
+conda activate your_environment
+```
+
+### Alternative: Manual Installation from Source
+
+If you prefer to install `VaMPy` from source, follow these steps:
+
 ### Step 1:  Clone the `VaMPy` repository
 
 Start by downloading and navigating to the root directory of `VaMPy` with the following command in your terminal:


### PR DESCRIPTION
`VaMPy` is now on `conda-forge` thanks to @johannesring. To reflect that, this PR updates the installation instructions.